### PR TITLE
DM-25407: ap_verify cannot handle curated crosstalk data in Gen 2

### DIFF
--- a/config/datasetIngest.py
+++ b/config/datasetIngest.py
@@ -6,4 +6,4 @@ config.refcats = {
 }
 
 # Workaround for DM-24395
-config.defectIngester.register.visit = ['calibDate', 'filter']
+config.curatedCalibIngester.register.visit = ['calibDate', 'filter']


### PR DESCRIPTION
This PR edits `datasetIngest.py` for the changes made to `DatasetIngestConfig` in lsst/ap_verify#91.