### PR TITLE
DM-29344: Investigate the CI differences between Gen 2 and 3 in COSMOS field

### DIFF
--- a/config/imageDifference.py
+++ b/config/imageDifference.py
@@ -3,3 +3,4 @@
 config.coaddName = "deep"
 config.getTemplate.coaddName = config.coaddName
 config.getTemplate.warpType = "direct"
+config.doScaleDiffimVariance = True


### PR DESCRIPTION
This PR sets `doScaleDiffimVariance` True in `config/imageDifference.py` so we get consistent results when the pipeline is run in gen2 and gen3. We definitely want to rescale the difference image variance when running the AP Pipeline on HSC data.