### PR TITLE
DM-29344: Investigate the CI differences between Gen 2 and 3 in COSMOS field (continued)

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -1,7 +1,6 @@
 # Config override for lsst.ip.isr.IsrTask
 
 # Can't ingest the necessary datasets
-config.doBrighterFatter = False
 config.doAttachTransmissionCurve = False
 config.doUseOpticsTransmission = False
 config.doUseFilterTransmission = False


### PR DESCRIPTION
This PR removes the line in `config/isr.py` which explicitly turned off the brighter-fatter correction (in gen2) for this dataset. The goal is to match the gen3 results, which currently has brighter-fatter on by default.