### PR TITLE
DM-30199: Mark ap_verify dataset files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,7 @@ preloaded/calib/HSC/bias !filter !diff !merge
 preloaded/calib/HSC/dark !filter !diff !merge
 preloaded/calib/HSC/flat !filter !diff !merge
 preloaded/templates/ !filter !diff !merge
+
+# Must be updated any time Gen 3 repository is updated, but most changes
+# are not human-meaningful.
+config/export.yaml linguist-generated=true


### PR DESCRIPTION
This PR flags `config/export.yaml` as a machine-generated file. The primary benefit of doing so is that it will no longer appear as reviewable changes in repository updates.