### PR TITLE
DM-26140: Centralize Gen 3 pipeline configuration info for ap_verify datasets

### DIFF
--- a/config/apPipe.py
+++ b/config/apPipe.py
@@ -11,3 +11,5 @@ config.ccdProcessor.calibrate.load(os.path.join(configDir, 'calibrate.py'))
 
 # Use dataset's specific templates
 config.differencer.load(os.path.join(configDir, 'imageDifference.py'))
+config.transformDiaSrcCat.load(os.path.join(configDir, 'transformDiaSrcCat.py'))
+config.diaPipe.load(os.path.join(configDir, 'diaPipe.py'))

--- a/config/diaPipe.py
+++ b/config/diaPipe.py
@@ -1,0 +1,11 @@
+# Config override for lsst.ap.association.DiaPipelineTask
+# Templates are deepCoadds
+
+config.connections.coaddName = "deep"
+
+# TODO: redundant connection definitions workaround for DM-30210
+config.connections.diaSourceTable = "deepDiff_diaSrcTable"
+config.connections.diffIm = "deepDiff_differenceExp"
+config.connections.warpedExposure = "deepDiff_warpedExp"
+config.connections.associatedDiaSources = "deepDiff_assocDiaSrc"
+# TODO: end DM-30210 workaround

--- a/config/diaPipeWithFakes.py
+++ b/config/diaPipeWithFakes.py
@@ -1,0 +1,16 @@
+# Config override for lsst.ap.association.DiaPipelineTask
+# Templates are deepCoadds
+
+# This file is only needed to provide the explicit "fakes_" connections names
+# required by DM-30210. Once that issue is resolved, this file can be removed
+# and the pipeline can use diaPipe.py plus a direct override of fakesType.
+
+config.connections.fakesType = "fakes_"
+config.connections.coaddName = "deep"
+
+# TODO: redundant connection definitions workaround for DM-30210
+config.connections.diaSourceTable = "fakes_deepDiff_diaSrcTable"
+config.connections.diffIm = "fakes_deepDiff_differenceExp"
+config.connections.warpedExposure = "fakes_deepDiff_warpedExp"
+config.connections.associatedDiaSources = "fakes_deepDiff_assocDiaSrc"
+# TODO: end DM-30210 workaround

--- a/config/imageDifference.py
+++ b/config/imageDifference.py
@@ -6,8 +6,6 @@ config.connections.coaddName = "deep"
 config.coaddName = config.connections.coaddName
 config.getTemplate.coaddName = config.connections.coaddName
 
-config.getTemplate.warpType = "direct"
-
 # TODO: redundant connection definitions workaround for DM-30210
 config.connections.exposure = "calexp"
 config.connections.coaddExposures = "deepCoadd"

--- a/config/imageDifference.py
+++ b/config/imageDifference.py
@@ -1,5 +1,21 @@
 # Config override for lsst.pipe.tasks.imageDifference.ImageDifferenceTask
 # Templates are deepCoadds assembled with the CompareWarp algorithm
-config.coaddName = "deep"
-config.getTemplate.coaddName = config.coaddName
+
+config.connections.coaddName = "deep"
+# These two lines can be removed once ImageDifference no longer supports Gen 2
+config.coaddName = config.connections.coaddName
+config.getTemplate.coaddName = config.connections.coaddName
+
 config.getTemplate.warpType = "direct"
+
+# TODO: redundant connection definitions workaround for DM-30210
+config.connections.exposure = "calexp"
+config.connections.coaddExposures = "deepCoadd"
+config.connections.dcrCoadds = "dcrCoadd"
+config.connections.outputSchema = "deepDiff_diaSrc_schema"
+config.connections.subtractedExposure = "deepDiff_differenceExp"
+config.connections.scoreExposure = "deepDiff_scoreExp"
+config.connections.warpedExposure = "deepDiff_warpedExp"
+config.connections.matchedExposure = "deepDiff_matchedExp"
+config.connections.diaSources = "deepDiff_diaSrc"
+# TODO: end DM-30210 workaround

--- a/config/imageDifferenceWithFakes.py
+++ b/config/imageDifferenceWithFakes.py
@@ -1,0 +1,27 @@
+# Config override for lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+# Templates are deepCoadds assembled with the CompareWarp algorithm
+
+# This file is only needed to provide the explicit "fakes_" connections names
+# required by DM-30210. Once that issue is resolved, this file can be removed
+# and the pipeline can use imageDifference.py plus a direct override
+# of fakesType.
+
+config.connections.fakesType = "fakes_"
+config.connections.coaddName = "deep"
+# These two lines can be removed once ImageDifference no longer supports Gen 2
+config.coaddName = config.connections.coaddName
+config.getTemplate.coaddName = config.connections.coaddName
+
+config.getTemplate.warpType = "direct"
+
+# TODO: redundant connection definitions workaround for DM-30210
+config.connections.exposure = "fakes_calexp"
+config.connections.coaddExposures = "fakes_deepCoadd"
+config.connections.dcrCoadds = "fakes_dcrCoadd"
+config.connections.outputSchema = "fakes_deepDiff_diaSrc_schema"
+config.connections.subtractedExposure = "fakes_deepDiff_differenceExp"
+config.connections.scoreExposure = "fakes_deepDiff_scoreExp"
+config.connections.warpedExposure = "fakes_deepDiff_warpedExp"
+config.connections.matchedExposure = "fakes_deepDiff_matchedExp"
+config.connections.diaSources = "fakes_deepDiff_diaSrc"
+# TODO: end DM-30210 workaround

--- a/config/imageDifferenceWithFakes.py
+++ b/config/imageDifferenceWithFakes.py
@@ -12,8 +12,6 @@ config.connections.coaddName = "deep"
 config.coaddName = config.connections.coaddName
 config.getTemplate.coaddName = config.connections.coaddName
 
-config.getTemplate.warpType = "direct"
-
 # TODO: redundant connection definitions workaround for DM-30210
 config.connections.exposure = "fakes_calexp"
 config.connections.coaddExposures = "fakes_deepCoadd"

--- a/config/transformDiaSrcCat.py
+++ b/config/transformDiaSrcCat.py
@@ -1,0 +1,11 @@
+# Config override for lsst.ap.association.TransformDiaSourceCatalogTask
+# Templates are deepCoadds
+
+config.connections.coaddName = "deep"
+
+# TODO: redundant connection definitions workaround for DM-30210
+config.connections.diaSourceSchema = "deepDiff_diaSrc_schema"
+config.connections.diaSourceCat = "deepDiff_diaSrc"
+config.connections.diffIm = "deepDiff_differenceExp"
+config.connections.diaSourceTable = "deepDiff_diaSrcTable"
+# TODO: end DM-30210 workaround

--- a/config/transformDiaSrcCatWithFakes.py
+++ b/config/transformDiaSrcCatWithFakes.py
@@ -1,0 +1,17 @@
+# Config override for lsst.ap.association.TransformDiaSourceCatalogTask
+# Templates are deepCoadds
+
+# This file is only needed to provide the explicit "fakes_" connections names
+# required by DM-30210. Once that issue is resolved, this file can be removed
+# and the pipeline can use transformDiaSrcCat.py plus a direct override
+# of fakesType.
+
+config.connections.fakesType = "fakes_"
+config.connections.coaddName = "deep"
+
+# TODO: redundant connection definitions workaround for DM-30210
+config.connections.diaSourceSchema = "fakes_deepDiff_diaSrc_schema"
+config.connections.diaSourceCat = "fakes_deepDiff_diaSrc"
+config.connections.diffIm = "fakes_deepDiff_differenceExp"
+config.connections.diaSourceTable = "fakes_deepDiff_diaSrcTable"
+# TODO: end DM-30210 workaround

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -1,0 +1,40 @@
+description: End to end Alert Production pipeline specialized for CI-Cosmos-PDR2
+#
+# NOTES
+# Remember to run make_apdb.py and use the same configs for diaPipe
+# READ_UNCOMMITTED is required for sqlite APDBs, i.e.,
+# -c diaPipe:apdb.isolation_level: 'READ_UNCOMMITTED'
+# A db_url is always required, e.g.,
+# -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
+# Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
+# -c diaPipe:apdb.connection_timeout: 240
+#
+# This pipeline delegates to per-task config files to ensure consistency with Gen 2.
+# The config files can be merged into this once ap_verify no longer supports Gen 2.
+
+imports:
+  - location: $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipe.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      # Ignore missing calibrations
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/isr.py
+  calibrate:
+    class: lsst.pipe.tasks.calibrate.CalibrateTask
+    config:
+      # Use dataset's reference catalogs
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrate.py
+  imageDifference:
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    config:
+      # Use dataset's specific templates
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/imageDifference.py
+  transformDiaSrcCat:
+    class: lsst.ap.association.TransformDiaSourceCatalogTask
+    config:
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/transformDiaSrcCat.py
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/diaPipe.py

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -14,6 +14,19 @@ description: End to end Alert Production pipeline specialized for CI-Cosmos-PDR2
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipe.yaml
+parameters:
+  coaddName: deep
+  # TODO: redundant connection definitions workaround for DM-30210
+  template: deepCoadd
+  diaSrcCat: deepDiff_diaSrc
+  diaSrcSchema: deepDiff_diaSrc_schema
+  diaSrcParquet: deepDiff_diaSrcTable
+  diff: deepDiff_differenceExp
+  diffScore: deepDiff_scoreExp
+  diffWarp: deepDiff_warpedExp
+  diffMatch: deepDiff_matchedExp
+  assocSrc: deepDiff_assocDiaSrc
+  # TODO: end DM-30210 workaround
 tasks:
   isr:
     class: lsst.ip.isr.IsrTask

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -9,6 +9,19 @@ description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PD
 
 imports:
   - location: $AP_VERIFY_DIR/pipelines/HyperSuprimeCam/ApVerify.yaml
+parameters:
+  coaddName: deep
+  # TODO: redundant connection definitions workaround for DM-30210
+  template: deepCoadd
+  diaSrcCat: deepDiff_diaSrc
+  diaSrcSchema: deepDiff_diaSrc_schema
+  diaSrcParquet: deepDiff_diaSrcTable
+  diff: deepDiff_differenceExp
+  diffScore: deepDiff_scoreExp
+  diffWarp: deepDiff_warpedExp
+  diffMatch: deepDiff_matchedExp
+  assocSrc: deepDiff_assocDiaSrc
+  # TODO: end DM-30210 workaround
 tasks:
   isr:
     class: lsst.ip.isr.IsrTask

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -1,0 +1,35 @@
+description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PDR2
+#
+# This pipeline delegates to per-task config files to ensure consistency with Gen 2.
+# The config files can be merged into this once ap_verify no longer supports Gen 2.
+#
+# This pipeline does not depend on the local ApPipe.yaml, because the definition
+# of the primary ApVerify.yaml is more likely to change than the data-specific
+# overrides, and importing both pipelines can't merge changes to the same task.
+
+imports:
+  - location: $AP_VERIFY_DIR/pipelines/HyperSuprimeCam/ApVerify.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      # Ignore missing calibrations
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/isr.py
+  calibrate:
+    class: lsst.pipe.tasks.calibrate.CalibrateTask
+    config:
+      # Use dataset's reference catalogs
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrate.py
+  imageDifference:
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    config:
+      # Use dataset's specific templates
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/imageDifference.py
+  transformDiaSrcCat:
+    class: lsst.ap.association.TransformDiaSourceCatalogTask
+    config:
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/transformDiaSrcCat.py
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/diaPipe.py

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -10,6 +10,33 @@ description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PD
 
 imports:
   - location: $AP_VERIFY_DIR/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
+parameters:
+  coaddName: deep
+  fakesType: fakes_
+  # TODO: redundant connection definitions workaround for DM-30210
+  template: deepCoadd
+  diaSrcCat: deepDiff_diaSrc
+  diaSrcSchema: deepDiff_diaSrc_schema
+  diaSrcParquet: deepDiff_diaSrcTable
+  diff: deepDiff_differenceExp
+  diffScore: deepDiff_scoreExp
+  diffWarp: deepDiff_warpedExp
+  diffMatch: deepDiff_matchedExp
+  assocSrc: deepDiff_assocDiaSrc
+  fakesInput: fakes_fakeSourceCat
+  fakesPvi: fakes_calexp
+  fakesTemplate: fakes_deepCoadd
+  fakesDcrTemplate: fakes_dcrCoadd
+  fakesDiaSrcCat: fakes_deepDiff_diaSrc
+  fakesDiaSrcSchema: fakes_deepDiff_diaSrc_schema
+  fakesDiaSrcParquet: fakes_deepDiff_diaSrcTable
+  fakesDiff: fakes_deepDiff_differenceExp
+  fakesDiffScore: fakes_deepDiff_scoreExp
+  fakesDiffWarp: fakes_deepDiff_warpedExp
+  fakesDiffMatch: fakes_deepDiff_matchedExp
+  fakesAssocSrc: fakes_deepDiff_assocDiaSrc
+  fakesMatchedSrc: fakes_deepDiff_matchDiaSrc
+  # TODO: end DM-30210 workaround
 tasks:
   isr:
     class: lsst.ip.isr.IsrTask
@@ -21,21 +48,9 @@ tasks:
     config:
       # Use dataset's reference catalogs
       file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrate.py
-  coaddFakes:
-    class: lsst.pipe.tasks.insertFakes.InsertFakesTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.image: deepCoadd
-      connections.fakeCat: fakes_fakeSourceCat
-      connections.imageWithFakes: fakes_deepCoadd
-      # TODO: end DM-30210 workaround
   visitFakes:
     class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
     config:
-      connections.coaddName: deep
-      coaddName: deep
       python: |
         # Use dataset's reference catalogs
         import os.path
@@ -60,71 +75,3 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/diaPipeWithFakes.py
-  matchFakes:
-    class: lsst.pipe.tasks.matchFakes.MatchVariableFakesTask
-    config:
-      # Gen 3 only, so no need for a config file
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.fakeCat: fakes_fakeSourceCat
-      connections.diffIm: fakes_deepDiff_differenceExp
-      connections.associatedDiaSources: fakes_deepDiff_assocDiaSrc
-      connections.matchedDiaSources: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround
-  apFakesCompletenessMag20t22:
-    class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround
-  apFakesCompletenessMag22t24:
-    class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround
-  apFakesCompletenessMag24t26:
-    class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround
-  apFakesCountMag20t22:
-    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround
-  apFakesCountMag22t24:
-    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround
-  apFakesCountMag24t26:
-    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround
-  apFakesCount:
-    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
-    config:
-      connections.coaddName: deep
-      # TODO: redundant connection definitions workaround for DM-30210
-      connections.fakesType: fakes_
-      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
-      # TODO: end DM-30210 workaround

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -1,0 +1,130 @@
+description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PDR2
+#
+# This pipeline delegates to per-task config files to ensure consistency with Gen 2.
+# The config files can be merged into this once ap_verify no longer supports Gen 2.
+#
+# This pipeline does not depend on the local ApVerify.yaml, because the definition
+# of the primary ApVerifyWithFakes.yaml is more likely to change than the
+# data-specific overrides, and importing both pipelines can't merge changes to
+# the same task.
+
+imports:
+  - location: $AP_VERIFY_DIR/pipelines/HyperSuprimeCam/ApVerifyWithFakes.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTask
+    config:
+      # Ignore missing calibrations
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/isr.py
+  calibrate:
+    class: lsst.pipe.tasks.calibrate.CalibrateTask
+    config:
+      # Use dataset's reference catalogs
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrate.py
+  coaddFakes:
+    class: lsst.pipe.tasks.insertFakes.InsertFakesTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.image: deepCoadd
+      connections.fakeCat: fakes_fakeSourceCat
+      connections.imageWithFakes: fakes_deepCoadd
+      # TODO: end DM-30210 workaround
+  visitFakes:
+    class: lsst.pipe.tasks.processCcdWithFakes.ProcessCcdWithVariableFakesTask
+    config:
+      connections.coaddName: deep
+      coaddName: deep
+      python: |
+        # Use dataset's reference catalogs
+        import os.path
+        from lsst.utils import getPackageDir
+        config.calibrate.load(os.path.join(getPackageDir("ap_verify_ci_cosmos_pdr2"),
+                                           "config", "calibrate.py"))
+  imageDifferenceNoFakes:
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    config:
+      # Use dataset's specific templates
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/imageDifference.py
+  imageDifference:
+    class: lsst.pipe.tasks.imageDifference.ImageDifferenceTask
+    config:
+      # Use dataset's specific templates
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/imageDifferenceWithFakes.py
+  transformDiaSrcCat:
+    class: lsst.ap.association.TransformDiaSourceCatalogTask
+    config:
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/transformDiaSrcCatWithFakes.py
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/diaPipeWithFakes.py
+  matchFakes:
+    class: lsst.pipe.tasks.matchFakes.MatchVariableFakesTask
+    config:
+      # Gen 3 only, so no need for a config file
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.fakeCat: fakes_fakeSourceCat
+      connections.diffIm: fakes_deepDiff_differenceExp
+      connections.associatedDiaSources: fakes_deepDiff_assocDiaSrc
+      connections.matchedDiaSources: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround
+  apFakesCompletenessMag20t22:
+    class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround
+  apFakesCompletenessMag22t24:
+    class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround
+  apFakesCompletenessMag24t26:
+    class: lsst.ap.pipe.metrics.ApFakesCompletenessMetricTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround
+  apFakesCountMag20t22:
+    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround
+  apFakesCountMag22t24:
+    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround
+  apFakesCountMag24t26:
+    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround
+  apFakesCount:
+    class: lsst.ap.pipe.metrics.ApFakesCountMetricTask
+    config:
+      connections.coaddName: deep
+      # TODO: redundant connection definitions workaround for DM-30210
+      connections.fakesType: fakes_
+      connections.matchedFakes: fakes_deepDiff_matchDiaSrc
+      # TODO: end DM-30210 workaround


### PR DESCRIPTION
This PR adds missing dataset-specific config files (for use in both Gen 2 and Gen 3), and adds pipeline specializations for `ApPipe`, `ApVerify`, and `ApVerifyWithFakes`. These configurations depend on the instrument-specific pipelines in `ap_verify`, and not on each other, as the most likely and difficult to replicate changes will involve addition of new metrics or changes to the pipeline structure itself.