### PR TITLE
DM-42217: Incorporate ModelPackage Butler datasets into ap_verify

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.gz filter=lfs diff=lfs merge=lfs -text
 *.fz filter=lfs diff=lfs merge=lfs -text
 *.sqlite3 filter=lfs diff=lfs merge=lfs -text
+*.zip filter=lfs diff=lfs merge=lfs -text
+*.tar filter=lfs diff=lfs merge=lfs -text

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ path                  | description
 `config`              | Dataset-specific configs to help Stack code work with this dataset.
 `pipelines`           | Dataset-specific pipelines to run on this dataset.
 `dataIds.list`        | List of dataIds in this repo. For use in running Tasks. Currently set to run all Ids.
-`preloaded`           | A Gen 3 Butler repository containing HSC master calibs from the 2016 COSMOS campaign (or, where necessary, from 2015), coadded images for use as differencing templates, and PS1 reference catalog in HTM format for regions overlapping any visit in the dataset.
+`preloaded`           | A Gen 3 Butler repository containing HSC master calibs from the 2016 COSMOS campaign (or, where necessary, from 2015), coadded images for use as differencing templates, PS1 reference catalog in HTM format for regions overlapping any visit in the dataset, and a pretrained machine learning model for real/bogus classification.
 `scripts`             | Scripts and data for generating this dataset.
 
 

--- a/config/export.yaml
+++ b/config/export.yaml
@@ -3321,6 +3321,12 @@ data:
   timespan_end: null
 - type: collection
   collection_type: RUN
+  name: pretrained_models/rbResnet50-DC2
+  host: null
+  timespan_begin: null
+  timespan_end: null
+- type: collection
+  collection_type: RUN
   name: refcats/DM-28636
   host: null
   timespan_begin: null
@@ -3353,6 +3359,11 @@ data:
   - HSC/calib/DM-32378
 - type: collection
   collection_type: CHAINED
+  name: models
+  children:
+  - pretrained_models/rbResnet50-DC2
+- type: collection
+  collection_type: CHAINED
   name: refcats
   children:
   - refcats/DM-28636
@@ -3375,6 +3386,7 @@ data:
   - HSC/calib
   - refcats
   - sso
+  - models
 - type: dataset_type
   name: bfKernel
   dimensions:
@@ -9653,6 +9665,21 @@ data:
       patch: 52
     path: u/elhoward/DM-38242/templates/20230517T191130Z/goodSeeingCoadd/9813/52/g/goodSeeingCoadd_9813_52_g_hsc_rings_v1_u_elhoward_DM-38242_templates_20230517T191130Z.fits
     formatter: lsst.obs.base.formatters.fitsExposure.FitsExposureFormatter
+- type: dataset_type
+  name: pretrainedModelPackage
+  dimensions: []
+  storage_class: NNModelPackagePayload
+  is_calibration: false
+- type: dataset
+  dataset_type: pretrainedModelPackage
+  run: pretrained_models/rbResnet50-DC2
+  records:
+  - dataset_id:
+    - !uuid 'fa4ac3d7-4c50-4f8b-9084-3c4f29176a27'
+    data_id:
+    - {}
+    path: pretrained_models/rbResnet50-DC2/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_rbResnet50-DC2.zip
+    formatter: lsst.meas.transiNet.modelPackages.formatters.NNModelPackageFormatter
 - type: dataset_type
   name: ps1_pv3_3pi_20170110
   dimensions:

--- a/config/export.yaml
+++ b/config/export.yaml
@@ -1,6 +1,6 @@
 description: Butler Data Repository Export
 version: 1.0.2
-universe_version: 3
+universe_version: 4
 universe_namespace: daf_butler
 data:
 - type: dimension

--- a/config/rbClassify.py
+++ b/config/rbClassify.py
@@ -1,0 +1,6 @@
+# Config override for lsst.meas.transiNet.RBTransiNetTask
+# Ensure we're using the model that's actually in this dataset,
+# regardless of what task defaults are.
+
+config.modelPackageStorageMode = "butler"
+config.modelPackageName = None

--- a/doc/ap_verify_ci_cosmos_pdr2/index.rst
+++ b/doc/ap_verify_ci_cosmos_pdr2/index.rst
@@ -32,6 +32,7 @@ It contains:
 * biases, darks, brighter-fatter kernels, and g-band flats.
 * reference catalogs for Pan-STARRS1, covering the raw images' footprint.
 * image differencing templates coadded from 2014 COSMOS data, covering the raw images' footprint.
+* the rbResnet50-DC2 pretrained machine learning model for real/bogus classification
 
 .. _ap_verify_ci_cosmos_pdr2-contributing:
 

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -28,6 +28,11 @@ tasks:
     config:
       # Use dataset's reference catalogs
       file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrate.py
+  rbClassify:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/rbClassify.py
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/ApPipeCalibrateImage.yaml
+++ b/pipelines/ApPipeCalibrateImage.yaml
@@ -29,6 +29,11 @@ tasks:
     config:
       # Use dataset's reference catalogs
       file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrateImage.py
+  rbClassify:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/rbClassify.py
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -25,6 +25,11 @@ tasks:
     config:
       # Use dataset's reference catalogs
       file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrate.py
+  rbClassify:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/rbClassify.py
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/ApVerifyCalibrateImage.yaml
+++ b/pipelines/ApVerifyCalibrateImage.yaml
@@ -26,6 +26,11 @@ tasks:
     config:
       # Use dataset's reference catalogs
       file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/calibrateImage.py
+  rbClassify:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/rbClassify.py
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -35,6 +35,11 @@ tasks:
         from lsst.utils import getPackageDir
         config.calibrate.load(os.path.join(getPackageDir("ap_verify_ci_cosmos_pdr2"),
                                            "config", "calibrate.py"))
+  rbClassifyWithFakes:
+    class: lsst.meas.transiNet.RBTransiNetTask
+    config:
+      # Use dataset's model
+      file: $AP_VERIFY_CI_COSMOS_PDR2_DIR/config/rbClassify.py
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57f593ecc12014cfed88f4c98985c1b7297b67cecc7a89f38e882628c1df52fb
-size 2818048
+oid sha256:c3c61cfe8ea414a67a5ae898423f64f35bc97c5c25d390a6fd10214aa1ea9a0f
+size 2945024

--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3c61cfe8ea414a67a5ae898423f64f35bc97c5c25d390a6fd10214aa1ea9a0f
+oid sha256:d43b15efd7ce0d3100ec1fb950549ee5b96e9590ff996acea309a1eed96e3e52
 size 2945024

--- a/preloaded/pretrained_models/rbResnet50-DC2/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_rbResnet50-DC2.zip
+++ b/preloaded/pretrained_models/rbResnet50-DC2/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_rbResnet50-DC2.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:40389d1a080cea368ca5a9ee09976b99d52b4c5f7d21493316f7656b2fccdf6b
+size 260417560

--- a/scripts/get_nn_models.py
+++ b/scripts/get_nn_models.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+# This file is part of ap_verify_dataset_template.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Script for ingesting pretrained neural net models for this dataset.
+
+Running this script allows for updates or replacements of the existing model.
+
+Example:
+$ python get_nn_models.py -m rbResnet50-DC2
+imports rbResnet50-DC2 from /repo/main to this dataset's preloaded repo. See
+get_nn_models.py -h for more options.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+import lsst.log
+import lsst.skymap
+from lsst.daf.butler import Butler, CollectionType
+from lsst.meas.transiNet.modelPackages.storageAdapterButler import StorageAdapterButler
+
+logging.basicConfig(level=logging.INFO, stream=sys.stdout)
+lsst.log.configure_pylog_MDC("DEBUG", MDC_class=None)
+
+
+MODEL_PREFIX = StorageAdapterButler.packages_parent_collection
+MODEL_CHAIN = "models"
+
+# Avoid explicit references to dataset package to maximize portability.
+SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
+DATASET_REPO = os.path.normpath(os.path.join(SCRIPT_DIR, "..", "preloaded"))
+
+
+########################################
+# Command-line options
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-b", dest="src_dir", default="/repo/main",
+                        help="Repo to import from, defaults to '/repo/main'.")
+    parser.add_argument("-m", dest="model_name", required=True,
+                        help="Model package to import.")
+    return parser
+
+
+args = _make_parser().parse_args()
+
+
+########################################
+# Clean up existing model
+
+def _clean_dataset(butler):
+    """Remove the previous model(s), to avoid clashes on load.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        A Butler pointing to the repository to be cleaned.
+    """
+    try:
+        model_runs = butler.registry.getCollectionChain(MODEL_CHAIN)
+    except lsst.daf.butler.registry.MissingCollectionError:
+        # No prior collections
+        return
+
+    butler.registry.setCollectionChain(MODEL_CHAIN, [])
+    butler.removeRuns(model_runs, unstore=True)
+
+
+dest = Butler(DATASET_REPO, writeable=True)
+_clean_dataset(dest)
+
+
+########################################
+# Transfer
+
+MODEL_COLLECT = f"{MODEL_PREFIX}/{args.model_name}"
+
+src = Butler(args.src_dir, writeable=False)
+dest.transfer_from(src, src.registry.queryDatasets(..., collections=MODEL_COLLECT),
+                   transfer="copy", register_dataset_types=True)
+
+dest.registry.registerCollection(MODEL_CHAIN, CollectionType.CHAINED)
+dest.registry.setCollectionChain(MODEL_CHAIN, [MODEL_COLLECT])
+
+logging.info(f"Model {args.model_name} stored in {DATASET_REPO}:{MODEL_CHAIN}.")


### PR DESCRIPTION
This PR adds the rbResnet50-DC2 real/bogus model, as well as a script for regenerating or replacing it in the future. This increases the download size from 2.0 GiB to 2.3 GiB.

****

- [X] Did you run `ap_verify.py` on this dataset?
- [X] Are the Sphinx documentation and readme up-to-date?
