### PR TITLE
DM-42419: Break up ApVerify into pure with- and without-fakes pipelines

### DIFF
--- a/pipelines/ApVerifyWithFakes.yaml
+++ b/pipelines/ApVerifyWithFakes.yaml
@@ -35,7 +35,7 @@ tasks:
         from lsst.utils import getPackageDir
         config.calibrate.load(os.path.join(getPackageDir("ap_verify_ci_cosmos_pdr2"),
                                            "config", "calibrate.py"))
-  rbClassifyWithFakes:
+  rbClassify:
     class: lsst.meas.transiNet.RBTransiNetTask
     config:
       # Use dataset's model


### PR DESCRIPTION
This PR updates the `ApVerifyWithFakes` pipeline to configure an `rbClassify` task rather than `rbClassifyWithFakes` (see lsst/ap_pipe#163).

****

- [X] Did you run `ap_verify.py` on this dataset?
- [X] Are the Sphinx documentation and readme up-to-date?