### PR TITLE
DM-40388: Switch AP pipelines to use new CalibrateImageTask

### DIFF
--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -1,4 +1,3 @@
-# TODO DM-40388: Remove this file, once the new pipeline is vetted.
 # Config override for lsst.pipe.tasks.calibrate.CalibrateTask
 # Ensure we're using the refcats that are actually in this dataset, regardless
 # of what task defaults are.

--- a/pipelines/ApPipe.yaml
+++ b/pipelines/ApPipe.yaml
@@ -1,4 +1,3 @@
-# TODO DM-40388: This file will replace ApPipe.yaml, once the new pipeline is vetted.
 description: End to end Alert Production pipeline specialized for CI-Cosmos-PDR2
 #
 # NOTES
@@ -9,7 +8,7 @@ description: End to end Alert Production pipeline specialized for CI-Cosmos-PDR2
 # -c diaPipe:apdb.connection_timeout: 240
 
 imports:
-  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipeCalibrateImage.yaml
+  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing

--- a/pipelines/ApPipeCalibrate.yaml
+++ b/pipelines/ApPipeCalibrate.yaml
@@ -1,11 +1,14 @@
-description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PDR2
+description: End to end Alert Production pipeline specialized for CI-Cosmos-PDR2
 #
-# This pipeline does not depend on the local ApPipe.yaml, because the definition
-# of the primary ApVerify.yaml is more likely to change than the data-specific
-# overrides, and importing both pipelines can't merge changes to the same task.
+# NOTES
+# Remember to run make_apdb.py and use the same configs for diaPipe
+# A db_url is always required, e.g.,
+# -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
+# Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
+# -c diaPipe:apdb.connection_timeout: 240
 
 imports:
-  - location: $AP_VERIFY_DIR/pipelines/HSC/ApVerify.yaml
+  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipeCalibrate.yaml
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing

--- a/pipelines/ApVerify.yaml
+++ b/pipelines/ApVerify.yaml
@@ -1,4 +1,3 @@
-# TODO DM-40388: This file will replace ApVerify.yaml, once the new pipeline is vetted.
 description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PDR2
 #
 # This pipeline does not depend on the local ApPipe.yaml, because the definition
@@ -6,7 +5,7 @@ description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PD
 # overrides, and importing both pipelines can't merge changes to the same task.
 
 imports:
-  - location: $AP_VERIFY_DIR/pipelines/HSC/ApVerifyCalibrateImage.yaml
+  - location: $AP_VERIFY_DIR/pipelines/HSC/ApVerify.yaml
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing

--- a/pipelines/ApVerifyCalibrate.yaml
+++ b/pipelines/ApVerifyCalibrate.yaml
@@ -1,14 +1,11 @@
-description: End to end Alert Production pipeline specialized for CI-Cosmos-PDR2
+description: Instrumented Alert Production pipeline specialized for CI-Cosmos-PDR2
 #
-# NOTES
-# Remember to run make_apdb.py and use the same configs for diaPipe
-# A db_url is always required, e.g.,
-# -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
-# Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
-# -c diaPipe:apdb.connection_timeout: 240
+# This pipeline does not depend on the local ApPipe.yaml, because the definition
+# of the primary ApVerify.yaml is more likely to change than the data-specific
+# overrides, and importing both pipelines can't merge changes to the same task.
 
 imports:
-  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
+  - location: $AP_VERIFY_DIR/pipelines/HSC/ApVerifyCalibrate.yaml
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing


### PR DESCRIPTION
- [x] Did you run `ap_verify.py` on this dataset?
- [x] Are the Sphinx documentation and readme up-to-date?
