### PR TITLE
Update ML reliability model to 2026-02-26

### DIFF
--- a/config/export.yaml
+++ b/config/export.yaml
@@ -920,7 +920,7 @@ data:
   timespan_end: null
 - type: collection
   collection_type: RUN
-  name: pretrained_models/tac_cnn_lsstcam_2026-02-13
+  name: pretrained_models/tac_cnn_lsstcam_2026-02-26
   host: null
   timespan_begin: null
   timespan_end: null
@@ -965,7 +965,7 @@ data:
   collection_type: CHAINED
   name: models
   children:
-  - pretrained_models/tac_cnn_lsstcam_2026-02-13
+  - pretrained_models/tac_cnn_lsstcam_2026-02-26
 - type: collection
   collection_type: CHAINED
   name: refcats
@@ -8119,13 +8119,13 @@ data:
   is_calibration: false
 - type: dataset
   dataset_type: pretrainedModelPackage
-  run: pretrained_models/tac_cnn_lsstcam_2026-02-13
+  run: pretrained_models/tac_cnn_lsstcam_2026-02-26
   records:
   - dataset_id:
-    - !uuid '019c6527-90d6-7163-a2d6-5f8f77306193'
+    - !uuid '019dacd7-1334-7f7a-83d0-bd71d9b0c2b0'
     data_id:
     - {}
-    path: pretrained_models/tac_cnn_lsstcam_2026-02-13/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_tac_cnn_lsstcam_2026-02-13.zip
+    path: pretrained_models/tac_cnn_lsstcam_2026-02-26/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_tac_cnn_lsstcam_2026-02-26.zip
     formatter: lsst.meas.transiNet.modelPackages.formatters.NNModelPackageFormatter
 - type: dataset_type
   name: ps1_pv3_3pi_20170110

--- a/doc/ap_verify_ci_cosmos_pdr2/index.rst
+++ b/doc/ap_verify_ci_cosmos_pdr2/index.rst
@@ -33,7 +33,7 @@ It contains:
 * reference catalogs for Pan-STARRS1, covering the raw images' footprint.
 * image differencing templates coadded from 2014 COSMOS data, covering the raw images' footprint.
 * mock APDB catalogs based on processing the raw images in order
-* the tac_cnn_lsstcam_2026-02-13 pretrained machine learning model for real/bogus classification
+* the v0.3 tac_cnn_lsstcam_2026-02-26 pretrained machine learning model for real/bogus classification
 
 .. _ap_verify_ci_cosmos_pdr2-contributing:
 

--- a/preloaded/gen3.sqlite3
+++ b/preloaded/gen3.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3d55ba43cb78a7def4137e111fff88a5a46946c0a6b8a878286218f939f9835c
+oid sha256:8d0c6d508240fe1360b59c13fabb2e23933e05470a4c608c7113dd983190feef
 size 3092480

--- a/preloaded/pretrained_models/tac_cnn_lsstcam_2026-02-13/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_tac_cnn_lsstcam_2026-02-13.zip
+++ b/preloaded/pretrained_models/tac_cnn_lsstcam_2026-02-13/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_tac_cnn_lsstcam_2026-02-13.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4997baa23d1f88221a84fb1f6d8ace69fead9f1d9f4d0c742f0362c95dce6a9
-size 817486

--- a/preloaded/pretrained_models/tac_cnn_lsstcam_2026-02-26/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_tac_cnn_lsstcam_2026-02-26.zip
+++ b/preloaded/pretrained_models/tac_cnn_lsstcam_2026-02-26/pretrainedModelPackage/pretrainedModelPackage_pretrained_models_tac_cnn_lsstcam_2026-02-26.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9f15255c7d7528a6fcb5378f2362d4fcc38d83c4945efdb03f25ae61a3c2d609
+size 823348

--- a/scripts/get_nn_models.py
+++ b/scripts/get_nn_models.py
@@ -85,7 +85,7 @@ def _clean_dataset(butler):
         return
 
     butler.registry.setCollectionChain(MODEL_CHAIN, [])
-    butler.removeRuns(model_runs, unstore=True)
+    butler.removeRuns(model_runs)
 
 
 dest = Butler(DATASET_REPO, writeable=True)


### PR DESCRIPTION
update to v0.3 model

****

- [X] Did you run `ap_verify.py` on this dataset?
- [ ] If you updated the data, have the maintenance scripts in `scripts/` been updated to match?
- [ ] If you made changes to `scripts/`, should those changes be propagated to [ap_verify_dataset_template](https://github.com/lsst-dm/ap_verify_dataset_template/), or are they specific to this data set?
- [X] Are the Sphinx documentation and readme up-to-date?
